### PR TITLE
Update to Geode v5.3.0 and migrated key bindings to the new api instead of the old custom keybinds mod

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,7 @@
+# 1.3.4
+- Updated to Geode 5.3.0
+- Migrated key bindings from the old custom keybinds mod, to the new keybind api of geode-sdk
+
 # 1.3.3
 - Fixed compatibility with Better Touch Priority (Shout out [undefined0](https://github.com/undefined06855) for the help)
 

--- a/mod.json
+++ b/mod.json
@@ -1,14 +1,14 @@
 {
-	"geode": "4.9.0",
+	"geode": "5.3.0",
 	"gd": {
-		"win": "2.2074",
-		"android": "2.2074",
-		"mac": "2.2074",
-		"ios": "2.2074"
+		"win": "2.2081",
+		"android": "2.2081",
+		"mac": "2.2081",
+		"ios": "2.2081"
 	},
 	"id": "bobby_shmurner.zoom",
 	"name": "Zoooom!",
-	"version": "1.3.3",
+	"version": "1.3.4",
 	"developer": "Bobby Shmurner",
 	"description": "Allows you to zoom while paused!",
 	"links": {
@@ -18,11 +18,6 @@
 		"geode.node-ids": {
 			"version": ">=v1.20.1",
 			"importance": "required"
-		},
-		"geode.custom-keybinds": {
-			"version": ">=v1.10.3",
-			"importance": "required",
-			"platforms": ["win", "mac"]
 		}
 	},
 	"resources": {

--- a/mod.json
+++ b/mod.json
@@ -64,6 +64,13 @@
 			"type": "bool",
 			"default": true,
 			"platforms": ["win", "mac"]
+		},
+		"toggle_menu": {
+			"name": "Toggle Pause Menu",
+			"description": "",
+			"type": "keybind",
+			"category": "gameplay",
+			"default": "Home"
 		}
 	}
 }

--- a/src/desktop.cpp
+++ b/src/desktop.cpp
@@ -170,15 +170,14 @@ void WindowsZoomManager::onScreenModified() {
 
 class $modify(PauseLayer) {
 	void customSetup() {
-
-        this->addEventListener(
-            KeybindSettingPressedEventV3(Mod::get(), "toggle_menu"_spr),
-            [this](Keybind const& keybind, bool down, bool repeat, double timestamp) {
-                if (down && !repeat) {
-                    // do something
-                }
-            }
-        );
+		this->addEventListener(
+			KeybindSettingPressedEventV3(Mod::get(), "toggle_menu"),
+			[this](Keybind const& keybind, bool down, bool repeat, double timestamp) {
+				if (down && !repeat) {
+					WindowsZoomManager::get()->togglePauseMenu();
+				}
+			}
+		);
 
 		PauseLayer::customSetup();
 	}
@@ -233,55 +232,19 @@ class $modify(CCScheduler) {
 	}
 };
 
-#ifdef GEODE_IS_WINDOWS
-//class $modify(CCEGLView) {
-//	void onGLFWMouseCallBack(GLFWwindow* window, int button, int action, int mods) {
-//		if (button == GLFW_MOUSE_BUTTON_MIDDLE) {
-//			if (action == GLFW_PRESS) {
-//				WindowsZoomManager::get()->isPanning = true;
-//			}
-//			else if (action == GLFW_RELEASE) {
-//				WindowsZoomManager::get()->isPanning = false;
-//			}
-//		}
-//
-//		CCEGLView::onGLFWMouseCallBack(window, button, action, mods);
-//	}
-//};
 $execute {
-    MouseInputEvent().listen([](MouseInputData& input) -> bool {
-        if (input.button == MouseInputData::Button::Middle) {
-            if (input.action == MouseInputData::Action::Press) {
-                WindowsZoomManager::get()->isPanning = true;
-            }
-            else if (input.action == MouseInputData::Action::Release) {
-                WindowsZoomManager::get()->isPanning = false;
-            }
-        }
-        return ListenerResult::Propagate;
-    }).leak();
+	MouseInputEvent().listen([](MouseInputData& input) -> bool {
+		if (input.button == MouseInputData::Button::Middle) {
+			if (input.action == MouseInputData::Action::Press) {
+				WindowsZoomManager::get()->isPanning = true;
+			}
+			else if (input.action == MouseInputData::Action::Release) {
+				WindowsZoomManager::get()->isPanning = false;
+			}
+		}
+		return ListenerResult::Propagate;
+	}).leak();
 }
-#else
-void otherMouseDownHook(void* self, SEL sel, void* event) {
-	WindowsZoomManager::get()->isPanning = true;
-	reinterpret_cast<void(*)(void*, SEL, void*)>(objc_msgSend)(self, sel, event);
-}
-
-void otherMouseUpHook(void* self, SEL sel, void* event) {
-	WindowsZoomManager::get()->isPanning = false;
-	reinterpret_cast<void(*)(void*, SEL, void*)>(objc_msgSend)(self, sel, event);
-}
-
-$execute {
-	if (auto hook = ObjcHook::create("EAGLView", "otherMouseDown:", &otherMouseDownHook)) {
-		(void) Mod::get()->claimHook(hook.unwrap());
-	}
-	
-	if (auto hook = ObjcHook::create("EAGLView", "otherMouseUp:", &otherMouseUpHook)) {
-		(void) Mod::get()->claimHook(hook.unwrap());
-	}
-}
-#endif // GEODE_IS_WINDOWS
 
 class $modify(CCMouseDispatcher) {
 	bool dispatchScrollMSG(float y, float x) {

--- a/src/desktop.cpp
+++ b/src/desktop.cpp
@@ -1,10 +1,8 @@
+#include <Geode/platform/cplatform.h>
 #ifdef GEODE_IS_DESKTOP
-
 #include "utils.hpp"
 #include "desktop.hpp"
 #include "settings.hpp"
-
-#include <geode.custom-keybinds/include/Keybinds.hpp>
 
 #include <Geode/Geode.hpp>
 
@@ -20,7 +18,6 @@
 #include <Geode/modify/CCScheduler.hpp>
 
 using namespace geode::prelude;
-using namespace keybinds;
 
 WindowsZoomManager* WindowsZoomManager::get() {
 	static auto inst = new WindowsZoomManager;
@@ -173,13 +170,15 @@ void WindowsZoomManager::onScreenModified() {
 
 class $modify(PauseLayer) {
 	void customSetup() {
-		this->template addEventListener<InvokeBindFilter>([=](InvokeBindEvent* event) {
-			if (event->isDown()) {
-				WindowsZoomManager::get()->togglePauseMenu();
-			}
 
-			return ListenerResult::Propagate;
-		}, "toggle_menu"_spr);
+        this->addEventListener(
+            KeybindSettingPressedEventV3(Mod::get(), "toggle_menu"_spr),
+            [this](Keybind const& keybind, bool down, bool repeat, double timestamp) {
+                if (down && !repeat) {
+                    // do something
+                }
+            }
+        );
 
 		PauseLayer::customSetup();
 	}
@@ -235,20 +234,33 @@ class $modify(CCScheduler) {
 };
 
 #ifdef GEODE_IS_WINDOWS
-class $modify(CCEGLView) {
-	void onGLFWMouseCallBack(GLFWwindow* window, int button, int action, int mods) {
-		if (button == GLFW_MOUSE_BUTTON_MIDDLE) {
-			if (action == GLFW_PRESS) {
-				WindowsZoomManager::get()->isPanning = true;
-			}
-			else if (action == GLFW_RELEASE) {
-				WindowsZoomManager::get()->isPanning = false;
-			}
-		}
-
-		CCEGLView::onGLFWMouseCallBack(window, button, action, mods);
-	}
-};
+//class $modify(CCEGLView) {
+//	void onGLFWMouseCallBack(GLFWwindow* window, int button, int action, int mods) {
+//		if (button == GLFW_MOUSE_BUTTON_MIDDLE) {
+//			if (action == GLFW_PRESS) {
+//				WindowsZoomManager::get()->isPanning = true;
+//			}
+//			else if (action == GLFW_RELEASE) {
+//				WindowsZoomManager::get()->isPanning = false;
+//			}
+//		}
+//
+//		CCEGLView::onGLFWMouseCallBack(window, button, action, mods);
+//	}
+//};
+$execute {
+    MouseInputEvent().listen([](MouseInputData& input) -> bool {
+        if (input.button == MouseInputData::Button::Middle) {
+            if (input.action == MouseInputData::Action::Press) {
+                WindowsZoomManager::get()->isPanning = true;
+            }
+            else if (input.action == MouseInputData::Action::Release) {
+                WindowsZoomManager::get()->isPanning = false;
+            }
+        }
+        return ListenerResult::Propagate;
+    }).leak();
+}
 #else
 void otherMouseDownHook(void* self, SEL sel, void* event) {
 	WindowsZoomManager::get()->isPanning = true;

--- a/src/desktop.hpp
+++ b/src/desktop.hpp
@@ -1,3 +1,4 @@
+#include <Geode/platform/cplatform.h>
 #ifdef GEODE_IS_DESKTOP
 #pragma once
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,11 +19,6 @@
 
 using namespace geode::prelude;
 
-float clamp(float d, float min, float max) {
-	const float t = d < min ? min : d;
-	return t > max ? max : t;
-}
-
 $execute {
 	geode::log::info("Zoom mod loaded!");
 	geode::log::info("Platform: " GEODE_PLATFORM_NAME);

--- a/src/mobile.cpp
+++ b/src/mobile.cpp
@@ -1,3 +1,4 @@
+#include <Geode/platform/cplatform.h>
 #ifdef GEODE_IS_MOBILE
 
 #include "utils.hpp"

--- a/src/mobile.hpp
+++ b/src/mobile.hpp
@@ -1,3 +1,4 @@
+#include <Geode/platform/cplatform.h>
 #ifdef GEODE_IS_MOBILE
 #pragma once
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -4,11 +4,6 @@
 
 using namespace geode::prelude;
 
-#ifdef GEODE_IS_DESKTOP
-#include <geode.custom-keybinds/include/Keybinds.hpp>
-using namespace keybinds;
-#endif
-
 SettingsManager* SettingsManager::get() {
 	static auto inst = new SettingsManager;
 	return inst;
@@ -17,32 +12,24 @@ SettingsManager* SettingsManager::get() {
 void SettingsManager::init() {
 	#ifdef GEODE_IS_DESKTOP
 	autoHideMenu = Mod::get()->getSettingValue<bool>("auto-hide-menu");
-	listenForSettingChanges("auto-hide-menu", [&](bool enable) {
+	listenForSettingChanges<bool>("auto-hide-menu", [&](bool enable) {
 		autoHideMenu = enable;
 	});
 
 	autoShowMenu = Mod::get()->getSettingValue<bool>("auto-show-menu");
-	listenForSettingChanges("auto-show-menu", [&](bool enable) {
+	listenForSettingChanges<bool>("auto-show-menu", [&](bool enable) {
 		autoShowMenu = enable;
 	});
 
 	altDisablesZoom = Mod::get()->getSettingValue<bool>("alt-disables-zoom");
-	listenForSettingChanges("alt-disables-zoom", [&](bool enable) {
+	listenForSettingChanges<bool>("alt-disables-zoom", [&](bool enable) {
 		altDisablesZoom = enable;
 	});
 
 	zoomSensitivity = Mod::get()->getSettingValue<float>("zoom-sensitivity");
-	listenForSettingChanges("zoom-sensitivity", [&](float sensitivity) {
+	listenForSettingChanges<bool>("zoom-sensitivity", [&](float sensitivity) {
 		zoomSensitivity = sensitivity;
 	});
 
-	BindManager::get()->registerBindable({
-		"toggle_menu"_spr,
-		"Toggle Pause Menu",
-		"",
-		{ Keybind::create(KEY_Home, Modifier::None) },
-		"Zoom",
-		false
-	});
-	#endif // GEODE_IS_DESKTOP
+    #endif
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1,6 +1,7 @@
 #include "settings.hpp"
 
 #include <Geode/Geode.hpp>
+#include <Geode/platform/cplatform.h>
 
 using namespace geode::prelude;
 
@@ -27,9 +28,9 @@ void SettingsManager::init() {
 	});
 
 	zoomSensitivity = Mod::get()->getSettingValue<float>("zoom-sensitivity");
-	listenForSettingChanges<bool>("zoom-sensitivity", [&](float sensitivity) {
+	listenForSettingChanges<float>("zoom-sensitivity", [&](float sensitivity) {
 		zoomSensitivity = sensitivity;
 	});
 
-    #endif
+	#endif // GEODE_IS_DESKTOP
 }

--- a/src/settings.hpp
+++ b/src/settings.hpp
@@ -1,14 +1,15 @@
 #pragma once
 
+#include <Geode/platform/cplatform.h>
 class SettingsManager {
 public:
 	static SettingsManager* get();
 	void init();
 
-	#ifdef GEODE_IS_DESKTOP
+#ifdef GEODE_IS_DESKTOP
 	bool autoHideMenu;
 	bool autoShowMenu;
 	bool altDisablesZoom;
 	float zoomSensitivity;
-	#endif
+#endif
 };

--- a/src/settings.hpp
+++ b/src/settings.hpp
@@ -6,10 +6,10 @@ public:
 	static SettingsManager* get();
 	void init();
 
-#ifdef GEODE_IS_DESKTOP
+	#ifdef GEODE_IS_DESKTOP
 	bool autoHideMenu;
 	bool autoShowMenu;
 	bool altDisablesZoom;
 	float zoomSensitivity;
-#endif
+	#endif
 };

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -47,8 +47,8 @@ void clampPlayLayerPos(CCNode* playLayer) {
 	float xLimit = (contentSize.width * playLayer->getScale() - screenSize.width) * 0.5f;
 	float yLimit = (contentSize.height * playLayer->getScale() - screenSize.height) * 0.5f;
 
-	pos.x = clamp(pos.x, -xLimit, xLimit);
-	pos.y = clamp(pos.y, -yLimit, yLimit);
+	pos.x = clampf(pos.x, -xLimit, xLimit);
+	pos.y = clampf(pos.y, -yLimit, yLimit);
 
 	playLayer->setPosition(pos);
 }


### PR DESCRIPTION
Only tested for windows (I can't test it on any other platform :{), but should work for other platforms as well. I tried keeping the same coding style as much as possible. For some reason the platform definitions didn't get defined during the build for this sdk version unless I add the `Geode/platform/cplatform.h` header.