### PR TITLE
Refactor UI code to follow Geode standards, fix mobile pause bug

### DIFF
--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+namespace zoom {
+    // Mobile UI
+    constexpr float kBackButtonOpacity = 100.0f;
+    constexpr float kBackButtonSizeMult = 1.15f;
+    constexpr float kBackButtonScale = 0.6f;
+    constexpr int kZoomLayerZOrder = 11;
+    constexpr int kTouchPriority = -250;
+    constexpr int kForcePriority = 2;
+    constexpr float kTouchZoomDivisor = 100.0f;
+    constexpr float kPauseZoomButtonScale = 0.6f;
+
+    // Desktop
+    constexpr float kSensitivityScale = 0.1f;
+    constexpr float kSmoothScrollDamping = 0.1f;
+    constexpr float kAutoShowZoomThreshold = 1.01f;
+
+    // Shared
+    constexpr float kMinZoom = 1.0f;
+    constexpr float kDefaultZoom = 1.0f;
+}

--- a/src/desktop.cpp
+++ b/src/desktop.cpp
@@ -3,6 +3,7 @@
 #include "utils.hpp"
 #include "desktop.hpp"
 #include "settings.hpp"
+#include "constants.hpp"
 
 #include <geode.custom-keybinds/include/Keybinds.hpp>
 
@@ -27,6 +28,10 @@ WindowsZoomManager* WindowsZoomManager::get() {
 	return inst;
 }
 
+CCNode* WindowsZoomManager::getPlayLayer() {
+	return CCScene::get()->getChildByID("PlayLayer");
+}
+
 void WindowsZoomManager::togglePauseMenu() {
 	if (!isPaused) return;
 
@@ -44,7 +49,7 @@ void WindowsZoomManager::setPauseMenuVisible(bool visible) {
 }
 
 void WindowsZoomManager::setZoom(float zoom) {
-	CCNode* playLayer = CCScene::get()->getChildByID("PlayLayer");
+	auto* playLayer = getPlayLayer();
 	if (!playLayer) return;
 
 	playLayer->setScale(zoom);
@@ -52,18 +57,16 @@ void WindowsZoomManager::setZoom(float zoom) {
 }
 
 void WindowsZoomManager::zoom(float delta) {
-	CCNode* playLayer = CCScene::get()->getChildByID("PlayLayer");
+	auto* playLayer = getPlayLayer();
 	if (!playLayer) return;
 
-	// CCPoint mouseScreenPos = getMousePosOnScreen();
 	CCPoint mousePos = getMousePos();
-
 	zoomPlayLayer(playLayer, delta, mousePos);
 	onScreenModified();
 }
 
 void WindowsZoomManager::move(CCPoint delta) {
-	CCNode* playLayer = CCScene::get()->getChildByID("PlayLayer");
+	auto* playLayer = getPlayLayer();
 	if (!playLayer) return;
 
 	CCPoint pos = playLayer->getPosition();
@@ -73,7 +76,7 @@ void WindowsZoomManager::move(CCPoint delta) {
 }
 
 void WindowsZoomManager::setPos(float x, float y) {
-	CCNode* playLayer = CCScene::get()->getChildByID("PlayLayer");
+	auto* playLayer = getPlayLayer();
 	if (!playLayer) return;
 
 	playLayer->setPosition(CCPoint{ x, y });
@@ -82,8 +85,8 @@ void WindowsZoomManager::setPos(float x, float y) {
 }
 
 float WindowsZoomManager::getZoom() {
-	CCNode* playLayer = CCScene::get()->getChildByID("PlayLayer");
-	if (!playLayer) return 1.0f;
+	auto* playLayer = getPlayLayer();
+	if (!playLayer) return zoom::kDefaultZoom;
 
 	return playLayer->getScale();
 }
@@ -92,12 +95,11 @@ CCPoint WindowsZoomManager::screenToWorld(CCPoint pos) {
 	CCSize screenSize = getScreenSize();
 	CCSize winSize = CCEGLView::get()->getFrameSize();
 
-	return CCPoint{ pos.x * (screenSize.width / winSize.width), pos.y * (screenSize.height / winSize.height) };
+	return CCPoint{
+		pos.x * (screenSize.width / winSize.width),
+		pos.y * (screenSize.height / winSize.height)
+	};
 }
-
-// CCPoint WindowsZoomManager::getMousePosOnScreen() {
-// 	return screenToWorld(getMousePos());
-// }
 
 CCPoint WindowsZoomManager::getMousePosOnNode(CCNode* node) {
 	return node->convertToNodeSpace(getMousePos());
@@ -105,36 +107,34 @@ CCPoint WindowsZoomManager::getMousePosOnNode(CCNode* node) {
 
 void WindowsZoomManager::update(float dt) {
 	auto mousePos = getMousePos();
-	auto lastMousePos = WindowsZoomManager::get()->lastMousePos;
 
-	WindowsZoomManager::get()->deltaMousePos = CCPoint{ mousePos.x - lastMousePos.x, mousePos.y - lastMousePos.y };
-	WindowsZoomManager::get()->lastMousePos = mousePos;
+	deltaMousePos = CCPoint{ mousePos.x - lastMousePos.x, mousePos.y - lastMousePos.y };
+	lastMousePos = mousePos;
 
 	if (!isPaused) return;
 
 	if (isPanning) {
-		CCPoint delta = WindowsZoomManager::get()->deltaMousePos;
-		move(delta);
+		move(deltaMousePos);
 	}
 }
 
 void WindowsZoomManager::onResume() {
-	setZoom(1.0f);
+	setZoom(zoom::kDefaultZoom);
 	setPos(0.0f, 0.0f);
 
 	isPaused = false;
-	WindowsZoomManager::get()->isPanning = false;
+	isPanning = false;
 }
 
 void WindowsZoomManager::onPause() {
 	isPaused = true;
-	WindowsZoomManager::get()->isPanning = false;
+	isPanning = false;
 }
 
 void WindowsZoomManager::onScroll(float y, float x) {
 	if (!isPaused) return;
 
-	CCNode* playLayer = CCScene::get()->getChildByID("PlayLayer");
+	auto* playLayer = getPlayLayer();
 	if (!playLayer) return;
 
 	if (SettingsManager::get()->altDisablesZoom) {
@@ -143,19 +143,20 @@ void WindowsZoomManager::onScroll(float y, float x) {
 			return;
 		}
 	}
-	
-	float zoomDelta = SettingsManager::get()->zoomSensitivity * 0.1f;
-	
+
+	float baseDelta = SettingsManager::get()->zoomSensitivity * zoom::kSensitivityScale;
+
 	if (Loader::get()->isModLoaded("prevter.smooth-scroll")) {
-		zoom(-y * zoomDelta * 0.1f);
+		zoom(-y * baseDelta * zoom::kSmoothScrollDamping);
 	} else if (y > 0) {
-		zoom(-zoomDelta);
+		zoom(-baseDelta);
 	} else {
-		zoom(zoomDelta);
+		zoom(baseDelta);
 	}
 
 	if (y > 0) {
-		if (SettingsManager::get()->autoShowMenu && playLayer->getScale() <= 1.01f) {
+		if (SettingsManager::get()->autoShowMenu &&
+			playLayer->getScale() <= zoom::kAutoShowZoomThreshold) {
 			setPauseMenuVisible(true);
 		}
 	} else {
@@ -164,11 +165,10 @@ void WindowsZoomManager::onScroll(float y, float x) {
 }
 
 void WindowsZoomManager::onScreenModified() {
-	CCNode* playLayer = CCScene::get()->getChildByID("PlayLayer");
+	auto* playLayer = getPlayLayer();
 	if (!playLayer) return;
 
 	clampPlayLayerPos(playLayer);
-	if (!isPaused) return;
 }
 
 class $modify(PauseLayer) {
@@ -225,6 +225,11 @@ class $modify(PlayLayer) {
 		WindowsZoomManager::get()->onResume();
 		return PlayLayer::init(level, useReplay, dontCreateObjects);
 	}
+
+	void levelComplete() {
+		WindowsZoomManager::get()->onResume();
+		PlayLayer::levelComplete();
+	}
 };
 
 class $modify(CCScheduler) {
@@ -250,6 +255,8 @@ class $modify(CCEGLView) {
 	}
 };
 #else
+// macOS requires reinterpret_cast for objc_msgSend trampolines —
+// this is the standard pattern for calling ObjC methods from C++.
 void otherMouseDownHook(void* self, SEL sel, void* event) {
 	WindowsZoomManager::get()->isPanning = true;
 	reinterpret_cast<void(*)(void*, SEL, void*)>(objc_msgSend)(self, sel, event);
@@ -264,7 +271,7 @@ $execute {
 	if (auto hook = ObjcHook::create("EAGLView", "otherMouseDown:", &otherMouseDownHook)) {
 		(void) Mod::get()->claimHook(hook.unwrap());
 	}
-	
+
 	if (auto hook = ObjcHook::create("EAGLView", "otherMouseUp:", &otherMouseUpHook)) {
 		(void) Mod::get()->claimHook(hook.unwrap());
 	}

--- a/src/desktop.hpp
+++ b/src/desktop.hpp
@@ -7,11 +7,11 @@ using namespace geode::prelude;
 
 class WindowsZoomManager {
 public:
-	CCPoint lastMousePos;
-	CCPoint deltaMousePos;
+	CCPoint lastMousePos{};
+	CCPoint deltaMousePos{};
 
-	bool isPaused;
-	bool isPanning;
+	bool isPaused = false;
+	bool isPanning = false;
 
 	static WindowsZoomManager* get();
 
@@ -27,13 +27,13 @@ public:
 	void move(CCPoint delta);
 
 	float getZoom();
-	// CCPoint getMousePosOnScreen();
 	CCPoint getMousePosOnNode(CCNode* node);
-	
+
 	void onResume();
 	void onPause();
 	void onScroll(float y, float x);
 private:
+	CCNode* getPlayLayer();
 	void onScreenModified();
 };
 #endif // GEODE_IS_DESKTOP

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,15 +1,4 @@
-#include <charconv>
-
 #include <Geode/Geode.hpp>
-
-#include <Geode/modify/MenuLayer.hpp>
-#include <Geode/modify/PauseLayer.hpp>
-#include <Geode/modify/CCKeyboardDispatcher.hpp>
-#include <Geode/modify/CCMouseDispatcher.hpp>
-#include <Geode/modify/PlayLayer.hpp>
-#include <Geode/modify/CCEGLView.hpp>
-#include <Geode/modify/CCApplication.hpp>
-#include <Geode/modify/CCScheduler.hpp>
 
 #include "settings.hpp"
 
@@ -18,11 +7,6 @@
 #endif
 
 using namespace geode::prelude;
-
-float clamp(float d, float min, float max) {
-	const float t = d < min ? min : d;
-	return t > max ? max : t;
-}
 
 $execute {
 	geode::log::info("Zoom mod loaded!");

--- a/src/mobile.cpp
+++ b/src/mobile.cpp
@@ -3,6 +3,7 @@
 #include "utils.hpp"
 #include "mobile.hpp"
 #include "settings.hpp"
+#include "constants.hpp"
 
 #include <algorithm>
 #include <Geode/modify/PauseLayer.hpp>
@@ -12,8 +13,8 @@ AndroidZoomLayer* AndroidZoomLayer::instance = nullptr;
 
 AndroidZoomLayer* AndroidZoomLayer::create(CCNode* sceneLayer) {
 	if (instance) {
-		instance = nullptr;
-		geode::log::info("AndroidZoomLayer already exists, deleting it!");
+		geode::log::info("AndroidZoomLayer already exists, cleaning up!");
+		instance->onBackButton(nullptr);
 	}
 
 	auto layer = new AndroidZoomLayer();
@@ -45,7 +46,6 @@ bool AndroidZoomLayer::init(CCNode* sceneLayer) {
 	m_sceneLayer->addChild(this);
 
 	m_playLayer = m_sceneLayer->getChildByID("PlayLayer");
-
 	if (!m_playLayer) {
 		geode::log::error("PlayLayer is null!");
 		return false;
@@ -59,43 +59,62 @@ bool AndroidZoomLayer::init(CCNode* sceneLayer) {
 
 	m_pauseLayer->setVisible(false);
 
-	// Thanks SillyDoggo for the code snippet :D
-	// https://github.com/TheSillyDoggo/GeodeMenu/blob/17b19215b80a263379a560edfaf63c2a3f17e2f8/src/Client/AndroidUI.cpp#L28
-
-	auto backMenu = CCMenu::create();
-	backMenu->ignoreAnchorPointForPosition(false);
-	backMenu->setContentSize(ccp(0, 0));
-	backMenu->setPositionX(0);
-	backMenu->setPositionY(CCDirector::get()->getWinSize().height);
-	backMenu->setID("back-menu");
-	this->addChild(backMenu);
+	// Back button setup
+	m_backMenu = CCMenu::create();
+	m_backMenu->setID("back-menu"_spr);
+	m_backMenu->setContentSize({ 50.0f, 50.0f });
+	m_backMenu->setAnchorPoint({ 0.0f, 1.0f });
 
 	auto backSpr = CCSprite::createWithSpriteFrameName("GJ_arrow_03_001.png");
-	backSpr->setOpacity(100);
+	backSpr->setOpacity(static_cast<GLubyte>(zoom::kBackButtonOpacity));
 
-	auto backBtn = CCMenuItemSpriteExtra::create(backSpr, this, menu_selector(AndroidZoomLayer::onBackButton));
-	backBtn->setPosition(ccp(24, -23));
-	backBtn->setSizeMult(1.15f);
+	auto backBtn = CCMenuItemSpriteExtra::create(
+		backSpr, this, menu_selector(AndroidZoomLayer::onBackButton));
+	backBtn->setID("back-button"_spr);
+	backBtn->setSizeMult(zoom::kBackButtonSizeMult);
 
-	backMenu->addChild(backBtn);
+	m_backMenu->addChild(backBtn);
+	this->addChildAtPosition(m_backMenu, Anchor::TopLeft, { 24.0f, -23.0f });
 
 	this->setID("AndroidZoomLayer"_spr);
-    this->setZOrder(11); // One above PauseLayer
+	this->setZOrder(zoom::kZoomLayerZOrder);
 
-	CCDirector::sharedDirector()->getTouchDispatcher()->addTargetedDelegate(this, -250, true);
+	CCDirector::sharedDirector()->getTouchDispatcher()->addTargetedDelegate(
+		this, zoom::kTouchPriority, true);
 	this->setTouchEnabled(true);
 
-	backMenu->setTouchPriority(CCDirector::sharedDirector()->getTouchDispatcher()->getTargetPrio());
-	CCDirector::sharedDirector()->getTouchDispatcher()->registerForcePrio(backMenu, 2);
+	m_backMenu->setTouchPriority(
+		CCDirector::sharedDirector()->getTouchDispatcher()->getTargetPrio());
+	CCDirector::sharedDirector()->getTouchDispatcher()->registerForcePrio(
+		m_backMenu, zoom::kForcePriority);
 
 	geode::log::info("AndroidZoomLayer initialized!");
 	return true;
 }
 
+void AndroidZoomLayer::cleanup() {
+	auto dispatcher = CCDirector::sharedDirector()->getTouchDispatcher();
+
+	if (m_backMenu) {
+		dispatcher->unregisterForcePrio(m_backMenu);
+	}
+
+	dispatcher->removeDelegate(this);
+	this->setTouchEnabled(false);
+
+	CCLayer::cleanup();
+}
+
 void AndroidZoomLayer::onBackButton(CCObject* sender) {
-	m_playLayer->setScale(1.0f);
-	m_playLayer->setPosition(ccp(0, 0));
-	m_pauseLayer->setVisible(true);
+	if (m_playLayer) {
+		m_playLayer->setScale(zoom::kDefaultZoom);
+		m_playLayer->setPosition(ccp(0, 0));
+	}
+
+	if (m_pauseLayer) {
+		m_pauseLayer->setVisible(true);
+	}
+
 	this->removeFromParentAndCleanup(true);
 	AndroidZoomLayer::instance = nullptr;
 }
@@ -141,7 +160,7 @@ void AndroidZoomLayer::ccTouchMoved(CCTouch* pTouch, CCEvent* pEvent) {
 
 		CCPoint delta = movingTouch->getDelta();
 		CCPoint touchDisplacement = ccpSub(movingTouch->getLocation(), anchoredTouch->getLocation());
-		float scaleDelta = touchDisplacement.normalize().dot(delta) / 100.0f;
+		float scaleDelta = touchDisplacement.normalize().dot(delta) / zoom::kTouchZoomDivisor;
 
 		zoomPlayLayer(m_playLayer, scaleDelta, m_ZoomAnchor);
 		clampPlayLayerPos(m_playLayer);
@@ -181,11 +200,15 @@ class $modify(AndroidZoomPauseLayer, PauseLayer) {
 
 		auto rightButtonMenu = getChildByID("right-button-menu");
 
-		auto zoomButtonSprite = CircleButtonSprite::createWithSprite("zoom_button.png"_spr, 1.0f, CircleBaseColor::Green, CircleBaseSize::MediumAlt);
+		auto zoomButtonSprite = CircleButtonSprite::createWithSprite(
+			"zoom_button.png"_spr, 1.0f,
+			CircleBaseColor::Green, CircleBaseSize::MediumAlt);
 		zoomButtonSprite->getTopNode()->setScale(1.0f);
-		zoomButtonSprite->setScale(0.6f);
+		zoomButtonSprite->setScale(zoom::kPauseZoomButtonScale);
 
-		auto zoomButton = CCMenuItemSpriteExtra::create(zoomButtonSprite, this, menu_selector(AndroidZoomPauseLayer::onZoomButton));
+		auto zoomButton = CCMenuItemSpriteExtra::create(
+			zoomButtonSprite, this,
+			menu_selector(AndroidZoomPauseLayer::onZoomButton));
 		zoomButton->setID("zoom-button"_spr);
 
 		rightButtonMenu->addChild(zoomButton);

--- a/src/mobile.hpp
+++ b/src/mobile.hpp
@@ -17,17 +17,18 @@ public:
 	void ccTouchEnded(CCTouch* pTouch, CCEvent* pEvent) override;
 	void ccTouchCancelled(CCTouch* pTouch, CCEvent* pEvent) override;
 	void onBackButton(CCObject* sender);
-	void onBackButton23(CCObject* sender);
 	void removeTouchEvent(CCTouch* pTouch, CCEvent* pEvent);
+	void cleanup();
 private:
 	CCPoint getAnchorPoint(CCTouch* touch1, CCTouch* touch2);
 
 	bool m_isZooming = false;
 	CCPoint m_ZoomAnchor = ccp(0, 0);
 
-	CCNode* m_sceneLayer;
-	CCNode* m_playLayer;
-	CCNode* m_pauseLayer;
+	CCNode* m_sceneLayer = nullptr;
+	CCNode* m_playLayer = nullptr;
+	CCNode* m_pauseLayer = nullptr;
+	CCMenu* m_backMenu = nullptr;
 	std::vector<CCTouch*> m_touches = {};
 };
 

--- a/src/settings.hpp
+++ b/src/settings.hpp
@@ -6,9 +6,9 @@ public:
 	void init();
 
 	#ifdef GEODE_IS_DESKTOP
-	bool autoHideMenu;
-	bool autoShowMenu;
-	bool altDisablesZoom;
-	float zoomSensitivity;
+	bool autoHideMenu = true;
+	bool autoShowMenu = true;
+	bool altDisablesZoom = true;
+	float zoomSensitivity = 1.0f;
 	#endif
 };

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,4 +1,8 @@
 #include "utils.hpp"
+#include "constants.hpp"
+
+#include <algorithm>
+
 using namespace geode::prelude;
 
 void zoomPlayLayer(CCNode* playLayer, float delta, CCPoint screenAnchor) {
@@ -19,8 +23,8 @@ void zoomPlayLayer(CCNode* playLayer, float delta, CCPoint screenAnchor) {
 		newScale = oldScale * (1 + delta);
 	}
 
-	if (newScale < 1.0f) newScale = 1.0f;
-	
+	if (newScale < zoom::kMinZoom) newScale = zoom::kMinZoom;
+
 	CCPoint deltaFromAnchorPrev = playLayer->getPosition() - anchorPoint;
 
 	playLayer->setPosition(anchorPoint);
@@ -47,8 +51,8 @@ void clampPlayLayerPos(CCNode* playLayer) {
 	float xLimit = (contentSize.width * playLayer->getScale() - screenSize.width) * 0.5f;
 	float yLimit = (contentSize.height * playLayer->getScale() - screenSize.height) * 0.5f;
 
-	pos.x = clamp(pos.x, -xLimit, xLimit);
-	pos.y = clamp(pos.y, -yLimit, yLimit);
+	pos.x = std::clamp(pos.x, -xLimit, xLimit);
+	pos.y = std::clamp(pos.y, -yLimit, yLimit);
 
 	playLayer->setPosition(pos);
 }


### PR DESCRIPTION
- Extract magic numbers into src/constants.hpp with named constants
- Fix mobile pause bug (issues #5, #6, #10, #14, #15): properly
  unregister touch delegates and force priority in cleanup() override,
  preventing stale touch state from blocking pause after zoom exit
- Fix singleton leak in AndroidZoomLayer::create() — old instance is
  now properly cleaned up instead of just nulling the pointer
- Fix potential crash on level complete while zoomed (issue #7): hook
  PlayLayer::levelComplete() to reset zoom before GD processes it
- Replace custom clamp() with std::clamp, remove dead includes from
  main.cpp (#include <charconv>, unused modify headers)
- Use addChildAtPosition with Anchor::TopLeft for back button instead
  of manual position calculations with ignoreAnchorPointForPosition
- Add node IDs (_spr namespaced) to back-menu and back-button
- Initialize all member variables (desktop.hpp, mobile.hpp, settings.hpp)
- Fix redundant WindowsZoomManager::get() calls within own member functions
- Extract getPlayLayer() helper to deduplicate 7 identical lookups
- Remove dead code: onBackButton23 declaration, commented-out methods

https://claude.ai/code/session_01NqsAjw4XEYgZMTjW1SKaze